### PR TITLE
General Code Improvement 1

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/FFmpeg.java
+++ b/src/main/java/net/bramp/ffmpeg/FFmpeg.java
@@ -31,9 +31,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class FFmpeg {
 
+  private static final String FFMPEG = "ffmpeg";
   final static Logger LOG = LoggerFactory.getLogger(FFmpeg.class);
 
-  final static String DEFAULT_PATH = MoreObjects.firstNonNull(System.getenv("FFMPEG"), "ffmpeg");
+  final static String DEFAULT_PATH = MoreObjects.firstNonNull(System.getenv("FFMPEG"), FFMPEG);
 
   public final static Fraction FPS_30 = Fraction.getFraction(30, 1);
   public final static Fraction FPS_29_97 = Fraction.getFraction(30000, 1001);
@@ -107,7 +108,7 @@ public class FFmpeg {
     this.version = version();
   }
 
-  private BufferedReader wrapInReader(Process p) {
+  private static BufferedReader wrapInReader(Process p) {
     return new BufferedReader(new InputStreamReader(p.getInputStream(), Charsets.UTF_8));
   }
 
@@ -118,7 +119,7 @@ public class FFmpeg {
       BufferedReader r = wrapInReader(p);
       version = r.readLine();
       IOUtils.copy(r, new NullOutputStream()); // Throw away rest of the output
-      FFmpegUtils.throwOnError("ffmpeg", p);
+      FFmpegUtils.throwOnError(FFMPEG, p);
     } finally {
       p.destroy();
     }
@@ -142,7 +143,7 @@ public class FFmpeg {
           codecs.add(new Codec(m.group(2), m.group(3), m.group(1)));
         }
 
-        FFmpegUtils.throwOnError("ffmpeg", p);
+        FFmpegUtils.throwOnError(FFMPEG, p);
         this.codecs = ImmutableList.copyOf(codecs);
       } finally {
         p.destroy();
@@ -170,7 +171,7 @@ public class FFmpeg {
           formats.add(new Format(m.group(2), m.group(3), m.group(1)));
         }
 
-        FFmpegUtils.throwOnError("ffmpeg", p);
+        FFmpegUtils.throwOnError(FFMPEG, p);
         this.formats = ImmutableList.copyOf(formats);
       } finally {
         p.destroy();
@@ -187,7 +188,7 @@ public class FFmpeg {
       // Now block reading ffmpeg's stdout. We are effectively throwing away the output.
       IOUtils.copy(wrapInReader(p), System.out); // TODO Should I be outputting to stdout?
 
-      FFmpegUtils.throwOnError("ffmpeg", p);
+      FFmpegUtils.throwOnError(FFMPEG, p);
 
     } finally {
       p.destroy();

--- a/src/main/java/net/bramp/ffmpeg/FFprobe.java
+++ b/src/main/java/net/bramp/ffmpeg/FFprobe.java
@@ -70,7 +70,7 @@ public class FFprobe {
     return path;
   }
 
-  private BufferedReader wrapInReader(Process p) {
+  private static BufferedReader wrapInReader(Process p) {
     return new BufferedReader(new InputStreamReader(p.getInputStream(), Charsets.UTF_8));
   }
 

--- a/src/main/java/net/bramp/ffmpeg/builder/FFmpegOutputBuilder.java
+++ b/src/main/java/net/bramp/ffmpeg/builder/FFmpegOutputBuilder.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class FFmpegOutputBuilder implements Cloneable {
 
+  private static final String BITRATE_MUST_BE_POSITIVE = "bitrate must be positive";
   final private static String DEVNULL = SystemUtils.IS_OS_WINDOWS ? "NUL" : "/dev/null";
 
   FFmpegBuilder parent;
@@ -123,7 +124,7 @@ public class FFmpegOutputBuilder implements Cloneable {
   }
 
   public FFmpegOutputBuilder setVideoBitRate(long bit_rate) {
-    Preconditions.checkArgument(bit_rate > 0, "bitrate must be positive");
+    Preconditions.checkArgument(bit_rate > 0, BITRATE_MUST_BE_POSITIVE);
     this.video_enabled = true;
     this.video_bit_rate = bit_rate;
     return this;
@@ -269,7 +270,7 @@ public class FFmpegOutputBuilder implements Cloneable {
    * @return this
    */
   public FFmpegOutputBuilder setAudioBitRate(long bit_rate) {
-    Preconditions.checkArgument(bit_rate > 0, "bitrate must be positive");
+    Preconditions.checkArgument(bit_rate > 0, BITRATE_MUST_BE_POSITIVE);
     this.audio_enabled = true;
     this.audio_bit_rate = bit_rate;
     return this;
@@ -338,7 +339,7 @@ public class FFmpegOutputBuilder implements Cloneable {
    * @return this
    */
   public FFmpegOutputBuilder setPassPaddingBitrate(long bitrate) {
-    Preconditions.checkArgument(bitrate > 0, "bitrate must be positive");
+    Preconditions.checkArgument(bitrate > 0, BITRATE_MUST_BE_POSITIVE);
     this.pass_padding_bitrate = bitrate;
     return this;
   }

--- a/src/main/java/net/bramp/ffmpeg/gson/NamedBitsetAdapter.java
+++ b/src/main/java/net/bramp/ffmpeg/gson/NamedBitsetAdapter.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class NamedBitsetAdapter<T> extends TypeAdapter<T> {
 
+  private static final String REFLECTION_ERROR = "Reflection error";
   final Class<T> clazz;
 
   public NamedBitsetAdapter(Class<T> clazz) {
@@ -81,9 +82,9 @@ public class NamedBitsetAdapter<T> extends TypeAdapter<T> {
       return obj;
 
     } catch (InstantiationException e) {
-      throw new IOException("Reflection error", e);
+      throw new IOException(REFLECTION_ERROR, e);
     } catch (IllegalAccessException e) {
-      throw new IOException("Reflection error", e);
+      throw new IOException(REFLECTION_ERROR, e);
     }
   }
 
@@ -114,7 +115,7 @@ public class NamedBitsetAdapter<T> extends TypeAdapter<T> {
         writer.value(b);
 
       } catch (IllegalAccessException e) {
-        throw new IOException("Reflection error", e);
+        throw new IOException(REFLECTION_ERROR, e);
       }
     }
     writer.endObject();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2325 'private' methods that don't access instance data should be 'static'
squid:S1192 String literals should not be duplicated

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2325
https://dev.eclipse.org/sonar/rules/show/squid:S1192

Please let me know if you have any questions.

Zeeshan Asghar