### PR TITLE
General Code Improvement 2

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/FFmpeg.java
+++ b/src/main/java/net/bramp/ffmpeg/FFmpeg.java
@@ -112,18 +112,18 @@ public class FFmpeg {
   }
 
   public synchronized @Nonnull String version() throws IOException {
-    String version;
+    String readVersion;
     Process p = runFunc.run(ImmutableList.of(path, "-version"));
     try {
       BufferedReader r = wrapInReader(p);
-      version = r.readLine();
+      readVersion = r.readLine();
       IOUtils.copy(r, new NullOutputStream()); // Throw away rest of the output
       FFmpegUtils.throwOnError("ffmpeg", p);
     } finally {
       p.destroy();
     }
 
-    return version;
+    return readVersion;
   }
 
   public synchronized @Nonnull List<Codec> codecs() throws IOException {

--- a/src/main/java/net/bramp/ffmpeg/builder/FFmpegOutputBuilder.java
+++ b/src/main/java/net/bramp/ffmpeg/builder/FFmpegOutputBuilder.java
@@ -372,8 +372,8 @@ public class FFmpegOutputBuilder implements Cloneable {
     if (targetSize > 0) {
       checkState(parent.inputs.size() == 1, "Target size does not support multiple inputs");
 
-      String filename = parent.inputs.get(0);
-      FFmpegProbeResult input = parent.inputProbes.get(filename);
+      String filenameAtZeroIndex = parent.inputs.get(0);
+      FFmpegProbeResult input = parent.inputProbes.get(filenameAtZeroIndex);
 
       checkState(input != null, "Target size must be used with setInput(FFmpegProbeResult)");
 
@@ -498,10 +498,5 @@ public class FFmpegOutputBuilder implements Cloneable {
     }
 
     return args.build();
-  }
-
-  @Override
-  public Object clone() throws CloneNotSupportedException {
-    return super.clone();
   }
 }

--- a/src/main/java/net/bramp/ffmpeg/gson/NamedBitsetAdapter.java
+++ b/src/main/java/net/bramp/ffmpeg/gson/NamedBitsetAdapter.java
@@ -94,7 +94,7 @@ public class NamedBitsetAdapter<T> extends TypeAdapter<T> {
       return;
     }
 
-    assert (value.getClass().equals(clazz));
+    assert value.getClass().equals(clazz);
 
     writer.beginObject();
     for (Field f : clazz.getFields()) {

--- a/src/main/java/net/bramp/ffmpeg/modelmapper/Mapper.java
+++ b/src/main/java/net/bramp/ffmpeg/modelmapper/Mapper.java
@@ -19,6 +19,10 @@ import static net.bramp.ffmpeg.modelmapper.NotDefaultCondition.notDefault;
  */
 public class Mapper {
 
+  private Mapper() {
+      throw new InstantiationError("Must not instantiate this class");
+  }
+
   final private static ModelMapper mapper = newModelMapper();
 
   private static <S, D> TypeMap<S, D> createTypeMap(ModelMapper mapper, Class<S> sourceType,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1118 Utility classes should not have public constructors
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding
squid:S1185 Overriding methods should do more than simply call the same method in the super class
squid:HiddenFieldCheck Local variables should not shadow class fields

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1185
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck

Please let me know if you have any questions.

Zeeshan Asghar