### PR TITLE
feat(FFmpegBuilder): support -f for input

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/builder/FFmpegBuilder.java
+++ b/src/main/java/net/bramp/ffmpeg/builder/FFmpegBuilder.java
@@ -43,6 +43,7 @@ public class FFmpegBuilder {
   String pass_prefix;
 
   // Input settings
+  String format;
   Long startOffset; // in millis
   final List<String> inputs = new ArrayList<>();
   final Map<String, FFmpegProbeResult> inputProbes = new TreeMap<>();
@@ -99,6 +100,12 @@ public class FFmpegBuilder {
     return addInput(filename);
   }
 
+  public FFmpegBuilder setFormat(String format) {
+    checkNotNull(format);
+    this.format = format;
+    return this;
+  }
+
   public FFmpegBuilder setStartOffset(long duration, TimeUnit units) {
     checkNotNull(duration);
     checkNotNull(units);
@@ -138,6 +145,10 @@ public class FFmpegBuilder {
 
     if (startOffset != null) {
       args.add("-ss").add(FFmpegUtils.millisecondsToString(startOffset));
+    }
+
+    if (format != null) {
+      args.add("-f", format);
     }
 
     for (String input : inputs) {

--- a/src/test/java/net/bramp/ffmpeg/FFmpegBuilderTest.java
+++ b/src/test/java/net/bramp/ffmpeg/FFmpegBuilderTest.java
@@ -30,16 +30,17 @@ public class FFmpegBuilderTest {
   public void testNormal() {
 
     FFmpegBuilder builder =
-        new FFmpegBuilder().setInput("input").setStartOffset(1500, TimeUnit.MILLISECONDS)
-            .overrideOutputFiles(true).addOutput("output").setFormat("mp4")
-            .setStartOffset(500, TimeUnit.MILLISECONDS).setAudioCodec("aac").setAudioChannels(1)
-            .setAudioSampleRate(48000).setVideoCodec("libx264").setVideoFrameRate(FFmpeg.FPS_30)
-            .setVideoResolution(320, 240).done();
+        new FFmpegBuilder().setFormat("customFormat").setInput("input")
+            .setStartOffset(1500, TimeUnit.MILLISECONDS).overrideOutputFiles(true)
+            .addOutput("output").setFormat("mp4").setStartOffset(500, TimeUnit.MILLISECONDS)
+            .setAudioCodec("aac").setAudioChannels(1).setAudioSampleRate(48000)
+            .setVideoCodec("libx264").setVideoFrameRate(FFmpeg.FPS_30).setVideoResolution(320, 240)
+            .done();
 
     List<String> args = builder.build();
-    assertThat(args, is(Arrays.asList("-y", "-v", "error", "-ss", "00:00:01.500", "-i", "input",
-        "-f", "mp4", "-ss", "00:00:00.500", "-vcodec", "libx264", "-s", "320x240", "-r", "30/1",
-        "-acodec", "aac", "-ac", "1", "-ar", "48000", "output")));
+    assertThat(args, is(Arrays.asList("-y", "-v", "error", "-ss", "00:00:01.500", "-f",
+        "customFormat", "-i", "input", "-f", "mp4", "-ss", "00:00:00.500", "-vcodec", "libx264",
+        "-s", "320x240", "-r", "30/1", "-acodec", "aac", "-ac", "1", "-ar", "48000", "output")));
   }
 
   @Test


### PR DESCRIPTION
In order to support the input format parameters, a format attribute have been added to the FFmpegBuilder class and handle in the build method.
The parameter is mandatory for some operation like concatenation without re-encode (https://www.ffmpeg.org/ffmpeg-formats.html#concat). With this extra parameter, we can generate a command line like this : /usr/local/bin/ffmpeg -f concat -i /path/to/file.txt -vcodec copy -acodec copy /path/to/file.mp4