### PR TITLE
feat(FFmpegBuilder): support -bsf:v and -bsf:a for bitstream filters

### DIFF
--- a/src/test/java/net/bramp/ffmpeg/FFmpegBuilderTest.java
+++ b/src/test/java/net/bramp/ffmpeg/FFmpegBuilderTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertThat;
 
 /**
  * -psnr
- * 
+ *
  * @author bramp
  *
  */
@@ -30,53 +30,55 @@ public class FFmpegBuilderTest {
   public void testNormal() {
 
     FFmpegBuilder builder =
-        new FFmpegBuilder().setFormat("customFormat").setInput("input")
-            .setStartOffset(1500, TimeUnit.MILLISECONDS).overrideOutputFiles(true)
-            .addOutput("output").setFormat("mp4").setStartOffset(500, TimeUnit.MILLISECONDS)
-            .setAudioCodec("aac").setAudioChannels(1).setAudioSampleRate(48000)
-            .setVideoCodec("libx264").setVideoFrameRate(FFmpeg.FPS_30).setVideoResolution(320, 240)
-            .done();
+            new FFmpegBuilder().setFormat("customFormat").setInput("input")
+                    .setStartOffset(1500, TimeUnit.MILLISECONDS).overrideOutputFiles(true)
+                    .addOutput("output").setFormat("mp4").setStartOffset(500, TimeUnit.MILLISECONDS)
+                    .setAudioCodec("aac").setAudioChannels(1).setAudioSampleRate(48000)
+                    .setAudioBitStreamFilter("bar").setVideoCodec("libx264")
+                    .setVideoFrameRate(FFmpeg.FPS_30).setVideoResolution(320, 240)
+                    .setVideoBitStreamFilter("foo").done();
 
     List<String> args = builder.build();
     assertThat(args, is(Arrays.asList("-y", "-v", "error", "-ss", "00:00:01.500", "-f",
-        "customFormat", "-i", "input", "-f", "mp4", "-ss", "00:00:00.500", "-vcodec", "libx264",
-        "-s", "320x240", "-r", "30/1", "-acodec", "aac", "-ac", "1", "-ar", "48000", "output")));
+            "customFormat", "-i", "input", "-f", "mp4", "-ss", "00:00:00.500", "-vcodec", "libx264",
+            "-s", "320x240", "-r", "30/1", "-bsf:v", "foo", "-acodec", "aac", "-ac", "1", "-ar",
+            "48000", "-bsf:a", "bar", "output")));
   }
 
   @Test
   public void testDisabled() {
 
     FFmpegBuilder builder =
-        new FFmpegBuilder().setInput("input").addOutput("output").disableAudio().disableSubtitle()
-            .disableVideo().done();
+            new FFmpegBuilder().setInput("input").addOutput("output").disableAudio().disableSubtitle()
+                    .disableVideo().done();
 
     List<String> args = builder.build();
     assertThat(args,
-        is(Arrays.asList("-y", "-v", "error", "-i", "input", "-vn", "-an", "-sn", "output")));
+            is(Arrays.asList("-y", "-v", "error", "-i", "input", "-vn", "-an", "-sn", "output")));
   }
 
   @Test
   public void testFilter() {
 
     FFmpegBuilder builder =
-        new FFmpegBuilder().setInput("input").addOutput("output").disableAudio().disableSubtitle()
-            .setVideoFilter("scale='trunc(ow/a/2)*2:320'").done();
+            new FFmpegBuilder().setInput("input").addOutput("output").disableAudio().disableSubtitle()
+                    .setVideoFilter("scale='trunc(ow/a/2)*2:320'").done();
 
     List<String> args = builder.build();
     assertThat(args, is(Arrays.asList("-y", "-v", "error", "-i", "input", "-vf",
-        "scale='trunc(ow/a/2)*2:320'", "-an", "-sn", "output")));
+            "scale='trunc(ow/a/2)*2:320'", "-an", "-sn", "output")));
   }
 
   @Test
   public void testFilter_and_scale() {
 
     FFmpegBuilder builder =
-        new FFmpegBuilder().setInput("input").addOutput("output").setVideoResolution(320, 240)
-            .setVideoFilter("scale='trunc(ow/a/2)*2:320'").done();
+            new FFmpegBuilder().setInput("input").addOutput("output").setVideoResolution(320, 240)
+                    .setVideoFilter("scale='trunc(ow/a/2)*2:320'").done();
 
     List<String> args = builder.build();
     assertThat(args, is(Arrays.asList("-y", "-v", "error", "-i", "input", "-s", "320x240", "-vf",
-        "scale='trunc(ow/a/2)*2:320'", "output")));
+            "scale='trunc(ow/a/2)*2:320'", "output")));
   }
 
   /**
@@ -86,14 +88,14 @@ public class FFmpegBuilderTest {
   public void testSetOptions() {
     MainEncodingOptions main = new MainEncodingOptions("mp4", 1500L, 2L);
     AudioEncodingOptions audio =
-        new AudioEncodingOptions(true, "aac", 1, FFmpeg.AUDIO_SAMPLE_48000, FFmpeg.AUDIO_DEPTH_S16,
-            1, 2);
+            new AudioEncodingOptions(true, "aac", 1, FFmpeg.AUDIO_SAMPLE_48000, FFmpeg.AUDIO_DEPTH_S16,
+                    1, 2);
     VideoEncodingOptions video =
-        new VideoEncodingOptions(true, "libx264", FFmpeg.FPS_30, 320, 240, 1, null, "", "");
+            new VideoEncodingOptions(true, "libx264", FFmpeg.FPS_30, 320, 240, 1, null, "", "");
 
     EncodingOptions options =
-        new FFmpegBuilder().setInput("input").addOutput("output").useOptions(main)
-            .useOptions(audio).useOptions(video).buildOptions();
+            new FFmpegBuilder().setInput("input").addOutput("output").useOptions(main)
+                    .useOptions(audio).useOptions(video).buildOptions();
 
     assertThat(main, reflectEquals(options.getMain()));
     assertThat(audio, reflectEquals(options.getAudio()));
@@ -103,11 +105,11 @@ public class FFmpegBuilderTest {
   @Test
   public void testMultipleOutputs() {
     List<String> args =
-        new FFmpegBuilder().setInput("input").addOutput("output1").setVideoResolution(320, 240)
-            .done().addOutput("output2").setVideoResolution(640, 480).done().build();
+            new FFmpegBuilder().setInput("input").addOutput("output1").setVideoResolution(320, 240)
+                    .done().addOutput("output2").setVideoResolution(640, 480).done().build();
 
     assertThat(args, is(Arrays.asList("-y", "-v", "error", "-i", "input", "-s", "320x240",
-        "output1", "-s", "640x480", "output2")));
+            "output1", "-s", "640x480", "output2")));
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
In order to add the possibility to use Bitstream filter for audio and video, some attribute have been added to the OutputBuilder so the parameters are integrated in the command line. This modification allow in my project (inked in this PR) to use the 'aac_adtstoasc' (https://www.ffmpeg.org/ffmpeg-bitstream-filters.html#aac_005fadtstoasc) which allow to merge a AAC and MP4 video together without re-encoding. This format t is the only one usable in web environnement without major re-enconding.

  The support of this bitstream filters are quiet simple in this PR, but it can be complexified to support parameters in future release.

@bramp Do you think it could be integrated in the future 0.5 if accepted ?

Linked to https://github.com/davinkevin/Podcast-Server/issues/68