### PR TITLE
feat(builder): set log level programmatically

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/builder/FFmpegBuilder.java
+++ b/src/main/java/net/bramp/ffmpeg/builder/FFmpegBuilder.java
@@ -39,10 +39,22 @@ public class FFmpegBuilder {
     }
   }
 
+  /*
+   * Log level options : https://ffmpeg.org/ffmpeg.html#Generic-options
+   */
+  public enum Verbosity {
+    QUIET, PANIC, FATAL, ERROR, WARNING, INFO, VERBOSE, DEBUG;
+
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
+
   // Global Settings
   boolean override = true;
   int pass = 0;
   String pass_prefix;
+  Verbosity verbosity = Verbosity.ERROR;
 
   // Input settings
   String format;
@@ -71,6 +83,12 @@ public class FFmpegBuilder {
 
   public FFmpegBuilder setPassPrefix(String prefix) {
     this.pass_prefix = prefix;
+    return this;
+  }
+
+  public FFmpegBuilder setVerbosity(Verbosity verbosity) {
+    checkNotNull(verbosity);
+    this.verbosity = verbosity;
     return this;
   }
 
@@ -164,7 +182,7 @@ public class FFmpegBuilder {
     Preconditions.checkArgument(!outputs.isEmpty(), "At least one output must be specified");
 
     args.add(override ? "-y" : "-n");
-    args.add("-v", "error"); // TODO make configurable
+    args.add("-v", this.verbosity.toString());
 
     if (startOffset != null) {
       args.add("-ss").add(FFmpegUtils.millisecondsToString(startOffset));

--- a/src/test/java/net/bramp/ffmpeg/builder/FFmpegBuilderTest.java
+++ b/src/test/java/net/bramp/ffmpeg/builder/FFmpegBuilderTest.java
@@ -1,7 +1,6 @@
 package net.bramp.ffmpeg.builder;
 
 import net.bramp.ffmpeg.FFmpeg;
-import net.bramp.ffmpeg.builder.FFmpegBuilder;
 import net.bramp.ffmpeg.options.AudioEncodingOptions;
 import net.bramp.ffmpeg.options.EncodingOptions;
 import net.bramp.ffmpeg.options.MainEncodingOptions;
@@ -14,6 +13,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.nitorcreations.Matchers.reflectEquals;
+import static net.bramp.ffmpeg.builder.FFmpegBuilder.*;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -31,6 +31,7 @@ public class FFmpegBuilderTest {
 
     // @formatter:off
     List<String> args = new FFmpegBuilder()
+        .setVerbosity(Verbosity.DEBUG)
         .setInput("input")
         .setStartOffset(1500, TimeUnit.MILLISECONDS)
         .overrideOutputFiles(true)
@@ -49,7 +50,7 @@ public class FFmpegBuilderTest {
         .build();
     // @formatter:on
 
-    assertThat(args, is(Arrays.asList("-y", "-v", "error", "-ss", "00:00:01.500", "-i", "input",
+    assertThat(args, is(Arrays.asList("-y", "-v", "debug", "-ss", "00:00:01.500", "-i", "input",
         "-f", "mp4", "-ss", "00:00:00.500", "-vcodec", "libx264", "-s", "320x240", "-r", "30/1",
         "-bsf:v", "foo", "-acodec", "aac", "-ac", "1", "-ar", "48000", "-bsf:a", "bar", "output")));
   }


### PR DESCRIPTION
I'v created an enum with all the possible value and define a default value in the builder to the previous hard coded level (ERROR). The user can set verbosity with method `setVerbosity(Verbosity v)`. 
This will help us to develop the issue #21 because we need a certain level of information to display / send the progresion of a ffmpeg operation