### PR TITLE
Refactor FFmpegOutputBuilderTestCheckValidStream

### DIFF
--- a/src/test/java/net/bramp/ffmpeg/builder/FFmpegOutputBuilderTestCheckInvalidStream.java
+++ b/src/test/java/net/bramp/ffmpeg/builder/FFmpegOutputBuilderTestCheckInvalidStream.java
@@ -1,0 +1,39 @@
+package net.bramp.ffmpeg.builder;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class FFmpegOutputBuilderTestCheckInvalidStream {
+
+	@Parameters(name="{0}")
+	public static List<String> data() {
+		return Arrays.asList(
+			// Bad schemes
+			"http://www.example.com/",
+			"https://live.twitch.tv/app/live_",
+			"ftp://236.0.0.1:2000",
+			// Missing ports
+			"udp://10.1.0.102/",
+			"tcp://127.0.0.1/"
+		);
+	}
+
+    private final URI uri;
+
+    public FFmpegOutputBuilderTestCheckInvalidStream(String url) {
+	this.uri = URI.create(url);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUri() {
+	FFmpegOutputBuilder.checkValidStream(uri);
+    }
+
+}

--- a/src/test/java/net/bramp/ffmpeg/builder/FFmpegOutputBuilderTestCheckValidStream.java
+++ b/src/test/java/net/bramp/ffmpeg/builder/FFmpegOutputBuilderTestCheckValidStream.java
@@ -1,81 +1,43 @@
 package net.bramp.ffmpeg.builder;
 
-import com.google.common.collect.ImmutableList;
-import org.junit.Test;
-
 import java.net.URI;
-import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class FFmpegOutputBuilderTestCheckValidStream {
 
-  // @formatter:off
-  static final List<String> goodURIs = ImmutableList.of(
-      "udp://10.1.0.102:1234",
-      "tcp://127.0.0.1:2000",
-      "udp://236.0.0.1:2000",
-      "rtmp://live.twitch.tv/app/live_",
-      "rtmp:///live/myStream.sdp",
-      "rtp://127.0.0.1:1234",
-      "rtsp://localhost:8888/live.sdp",
-      "rtsp://localhost:8888/live.sdp?tcp",
+    @Parameters(name = "{0}")
+    public static List<String> data() {
+        return Arrays.asList(
+	      "udp://10.1.0.102:1234",
+	      "tcp://127.0.0.1:2000",
+	      "udp://236.0.0.1:2000",
+	      "rtmp://live.twitch.tv/app/live_",
+	      "rtmp:///live/myStream.sdp",
+	      "rtp://127.0.0.1:1234",
+	      "rtsp://localhost:8888/live.sdp",
+	      "rtsp://localhost:8888/live.sdp?tcp",
 
-      // Some others
-      "UDP://10.1.0.102:1234"
-  );
-
-  static final List<String> badSchemes = ImmutableList.of(
-      "http://www.example.com/",
-      "https://live.twitch.tv/app/live_",
-      "ftp://236.0.0.1:2000"
-  );
-
-  static final List<String> missingPort = ImmutableList.of(
-      "udp://10.1.0.102/",
-      "tcp://127.0.0.1/"
-  );
-  // @formatter:on
-
-  protected void testForNoException(final List<String> list) throws URISyntaxException {
-    for (String url : list) {
-      URI u = new URI(url);
-      try {
-        FFmpegOutputBuilder.checkValidStream(u);
-
-      } catch (IllegalArgumentException e) {
-        fail("Unexpected error while handling '" + url + "': " + e.toString());
-      }
+	      // Some others
+	      "UDP://10.1.0.102:1234"
+		);
     }
-  }
 
-  protected void testForException(final List<String> list) throws URISyntaxException {
-    for (String url : badSchemes) {
-      URI u = new URI(url);
-      try {
-        FFmpegOutputBuilder.checkValidStream(u);
+    private final URI uri;
 
-      } catch (IllegalArgumentException e) {
-        continue;
-      }
-
-      fail("Expected error but none thrown for '" + url + "'");
+    public FFmpegOutputBuilderTestCheckValidStream(String url) {
+	this.uri = URI.create(url);
     }
-  }
 
-  @Test
-  public void testGoodURLs() throws URISyntaxException {
-    testForNoException(goodURIs);
-  }
+    @Test
+    public void testUri() {
+	FFmpegOutputBuilder.checkValidStream(uri);
+    }
 
-  @Test
-  public void testBadSchemes() throws URISyntaxException {
-    testForException(badSchemes);
-  }
-
-  @Test
-  public void testMissingPort() throws URISyntaxException {
-    testForException(missingPort);
-  }
 }


### PR DESCRIPTION
Use 2 distinct test classes for valid and invalid URIs.