### PR TITLE
Duplicating managed version for Cobertura

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
                     <format>xml</format>
                     <maxmem>256m</maxmem>
@@ -499,7 +498,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.7</version>
 				<configuration>
 					<aggregate>true</aggregate>
 					<outputDirectory>%{project.reporting.outputDirectory}/cobertura</outputDirectory>


### PR DESCRIPTION
Fix warning message "Duplicating managed version 2.7 for cobertura-maven-plugin" in Eclipse