### PR TITLE
Samples - Refactor MP4 file path

### DIFF
--- a/src/test/java/net/bramp/ffmpeg/fixtures/Samples.java
+++ b/src/test/java/net/bramp/ffmpeg/fixtures/Samples.java
@@ -5,8 +5,7 @@ public final class Samples {
     throw new AssertionError("No instances for you!");
   }
 
-  public static final String TEST_PREFIX = "src/test/resources/net/bramp/ffmpeg/samples/";
-  public static final String big_buck_bunny_720p_1mb = TEST_PREFIX + "big_buck_bunny_720p_1mb.mp4";
+  public static final String big_buck_bunny_720p_1mb = Samples.class.getResource("../samples/big_buck_bunny_720p_1mb.mp4").getPath();
 
   // We don't have the following files
   public static final String FAKE_PREFIX = "fake/";


### PR DESCRIPTION
+ Public constant `TEST_PREFIX` is not used, so we can remove it.
+ Improved the way to find sample video file, using class loader. So we do not expose Maven internal file organization.