### PR TITLE
Rewrite method millisecondsToString(long)

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/FFmpegUtils.java
+++ b/src/main/java/net/bramp/ffmpeg/FFmpegUtils.java
@@ -8,6 +8,7 @@ import net.bramp.ffmpeg.gson.NamedBitsetAdapter;
 import net.bramp.ffmpeg.probe.FFmpegDisposition;
 import org.apache.commons.lang3.math.Fraction;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -27,29 +28,29 @@ public final class FFmpegUtils {
   }
 
   /**
-   * Convert milliseconds to "hh:mm:ss.ms" String representation.
-   *
+   * Convert milliseconds to {@code [-]S+[.m...]} String representation.
+   * 
+   * <p>
+   * "{@code S}" expresses the number of seconds, with the optional decimal part "{@code m}".
+   * The optional "{@code -}" indicates negative duration.
+   * 
    * @param milliseconds time duration in milliseconds
-   * @return time duration in human-readable format
+   * @return time duration in seconds 
+   * @see <a href="https://www.ffmpeg.org/ffmpeg-utils.html#Time-duration">FFmpeg - Time duration</a>
    */
-  public static String millisecondsToString(long milliseconds) {
+  public static String millisecondsToString(final long milliseconds) {
     // FIXME Negative durations are also supported.
     // https://www.ffmpeg.org/ffmpeg-utils.html#Time-duration
     checkArgument(milliseconds >= 0, "milliseconds must be positive");
 
-    long seconds = milliseconds / 1000;
-    milliseconds = milliseconds - (seconds * 1000);
+    final long seconds = milliseconds / 1000;
+    final long decimalPart = milliseconds - (seconds * 1000);
+   
+    if (decimalPart == 0) {
+      return String.format(Locale.US, "%s", seconds);
+    }
 
-    long minutes = seconds / 60;
-    seconds = seconds - (minutes * 60);
-
-    long hours = minutes / 60;
-    minutes = minutes - (hours * 60);
-
-    if (milliseconds == 0)
-      return String.format("%02d:%02d:%02d", hours, minutes, seconds);
-
-    return String.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
+    return String.format(Locale.US, "%s.%s", seconds, decimalPart);
   }
 
   /**

--- a/src/test/java/net/bramp/ffmpeg/FFmpegUtilsTest.java
+++ b/src/test/java/net/bramp/ffmpeg/FFmpegUtilsTest.java
@@ -15,11 +15,11 @@ public class FFmpegUtilsTest {
 
   @Test
   public void testMillisecondsToString() {
-    assertEquals("00:01:03.123", millisecondsToString(63123));
-    assertEquals("00:01:03", millisecondsToString(63000));
-    assertEquals("01:23:45.678", millisecondsToString(5025678));
-    assertEquals("00:00:00", millisecondsToString(0));
-    assertEquals("2562047788015:12:55.807", millisecondsToString(Long.MAX_VALUE));
+    assertEquals("63.123", millisecondsToString(63123));
+    assertEquals("63", millisecondsToString(63000));
+    assertEquals("5025.678", millisecondsToString(5025678));
+    assertEquals("0", millisecondsToString(0));
+    assertEquals("9223372036854775.807", millisecondsToString(Long.MAX_VALUE));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/net/bramp/ffmpeg/builder/FFmpegBuilderTest.java
+++ b/src/test/java/net/bramp/ffmpeg/builder/FFmpegBuilderTest.java
@@ -63,7 +63,7 @@ public class FFmpegBuilderTest {
             "debug",
             "-user-agent",
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36",
-            "-ss", "00:00:01.500", "-i", "input", "-f", "mp4", "-ss", "00:00:00.500", "-vcodec",
+            "-ss", "1.500", "-i", "input", "-f", "mp4", "-ss", "0.500", "-vcodec",
             "libx264", "-s", "320x240", "-r", "30/1", "-bsf:v", "foo", "-acodec", "aac", "-ac",
             "1", "-ar", "48000", "-bsf:a", "bar", "output"));
   }


### PR DESCRIPTION
Rewrite method `FFmpegUtils#millisecondsToString(long)` to use plain time duration format `S+[.ms]` instead of `hh:mm:ss[.ms]`.

See [Fmpeg - Syntax - Time duration](https://www.ffmpeg.org/ffmpeg-utils.html#Time-duration).
