### PR TITLE
Fix for issue #86: Changed "bitrate" parsing of ffmpeg output: now expecting "N/A" value

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/FFmpegUtils.java
+++ b/src/main/java/net/bramp/ffmpeg/FFmpegUtils.java
@@ -98,6 +98,10 @@ public final class FFmpegUtils {
    * @return the bitrate in bits per second.
    */
   public static long parseBitrate(String bitrate) {
+    if (bitrate.equals("N/A")) {
+      return -1;
+    }
+
     Matcher m = BITRATE_REGEX.matcher(bitrate);
     if (!m.find()) {
       throw new IllegalArgumentException("Invalid bitrate '" + bitrate + "'");


### PR DESCRIPTION
Fix for this issue: https://github.com/bramp/ffmpeg-cli-wrapper/issues/86 FFmpegUtils.parseBitrate throws IllegalArgument when bitrate is 'N/A'

Checking if "bitrate" takes "N/A" value and returning -1 in that case