### PR TITLE
Fix #86: return -1 if given bitrate is 'N/A'

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/FFmpegUtils.java
+++ b/src/main/java/net/bramp/ffmpeg/FFmpegUtils.java
@@ -95,9 +95,12 @@ public final class FFmpegUtils {
    * Converts a string representation of bitrate to a long of bits per second
    *
    * @param bitrate in the form of 12.3kbits/s
-   * @return the bitrate in bits per second.
+   * @return the bitrate in bits per second or -1 if bitrate is 'N/A'
    */
   public static long parseBitrate(String bitrate) {
+    if ("N/A".equals(bitrate)) {
+      return -1;
+    }
     Matcher m = BITRATE_REGEX.matcher(bitrate);
     if (!m.find()) {
       throw new IllegalArgumentException("Invalid bitrate '" + bitrate + "'");

--- a/src/test/java/net/bramp/ffmpeg/FFmpegUtilsTest.java
+++ b/src/test/java/net/bramp/ffmpeg/FFmpegUtilsTest.java
@@ -60,6 +60,7 @@ public class FFmpegUtilsTest {
     assertEquals(12300, parseBitrate("12.3kbits/s"));
     assertEquals(1000, parseBitrate("1kbits/s"));
     assertEquals(123, parseBitrate("0.123kbits/s"));
+    assertEquals(-1, parseBitrate("N/A"));
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
A new pull request to fix bitrate parsing. The same solution (return -1 for 'N/A') with added javadoc and unit test.