### PR TITLE
Fix the audio and video filter arguments

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/builder/FFmpegBuilder.java
+++ b/src/main/java/net/bramp/ffmpeg/builder/FFmpegBuilder.java
@@ -320,11 +320,11 @@ public class FFmpegBuilder {
     }
 
     if (!Strings.isNullOrEmpty(videoFilter)) {
-      args.add("-af", videoFilter);
+      args.add("-vf", videoFilter);
     }
 
     if (!Strings.isNullOrEmpty(audioFilter)) {
-      args.add("-vf", audioFilter);
+      args.add("-af", audioFilter);
     }
 
     for (FFmpegOutputBuilder output : this.outputs) {

--- a/src/test/java/net/bramp/ffmpeg/ExamplesTest.java
+++ b/src/test/java/net/bramp/ffmpeg/ExamplesTest.java
@@ -210,4 +210,28 @@ public class ExamplesTest {
     String actual = Joiner.on(" ").join(ffmpeg.path(builder.build()));
     assertEquals(expected, actual);
   }
+
+  // Transcode to iOS HEVC format, with video filter set before output
+  @Test
+  public void testExample8() throws IOException {
+    FFmpegBuilder builder =
+            new FFmpegBuilder()
+                    .addInput("original.mp4")
+                    .setVideoFilter("select='gte(n\\,10)',scale=200:-1")
+                    .addOutput("hevc-video.mp4")
+                    .addExtraArgs("-tag:v", "hvc1")
+                    .setVideoCodec("libx265")
+                    .done();
+
+    String expected =
+            "ffmpeg -y -v error"
+                    + " -i original.mp4"
+                    + " -vf select='gte(n\\,10)',scale=200:-1"
+                    + " -vcodec libx265"
+                    + " -tag:v hvc1"
+                    + " hevc-video.mp4";
+
+    String actual = Joiner.on(" ").join(ffmpeg.path(builder.build()));
+    assertEquals(expected, actual);
+  }
 }


### PR DESCRIPTION
Just a quick pull request to fix the `-af` and `-vf` arguments. They were flipped.