### PR TITLE
Added support for input devices/streams and tests

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/builder/AbstractFFmpegStreamBuilder.java
+++ b/src/main/java/net/bramp/ffmpeg/builder/AbstractFFmpegStreamBuilder.java
@@ -66,6 +66,9 @@ public abstract class AbstractFFmpegStreamBuilder<T extends AbstractFFmpegStream
   /** Output filename or uri. Only one may be set */
   public String filename;
 
+  /** input filename or uri. Only one may be set */
+  public String input;
+
   public URI uri;
 
   public String format;
@@ -108,6 +111,11 @@ public abstract class AbstractFFmpegStreamBuilder<T extends AbstractFFmpegStream
 
   protected AbstractFFmpegStreamBuilder() {
     this.parent = null;
+  }
+
+  //used by input builders
+  protected AbstractFFmpegStreamBuilder(FFmpegBuilder parent){
+    this.parent = parent;
   }
 
   protected AbstractFFmpegStreamBuilder(FFmpegBuilder parent, String filename) {

--- a/src/main/java/net/bramp/ffmpeg/builder/FFmpegInputBuilder.java
+++ b/src/main/java/net/bramp/ffmpeg/builder/FFmpegInputBuilder.java
@@ -1,0 +1,100 @@
+package net.bramp.ffmpeg.builder;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import net.bramp.ffmpeg.options.EncodingOptions;
+import org.apache.commons.lang3.SystemUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static net.bramp.ffmpeg.Preconditions.checkNotEmpty;
+
+public class FFmpegInputBuilder extends AbstractFFmpegStreamBuilder<FFmpegInputBuilder> {
+
+    protected int thread_queue_size;
+    protected int device_number;                //device number for multiple devices with the same name
+    protected static final String DEVNULL = SystemUtils.IS_OS_WINDOWS ? "NUL" : "/dev/null";
+
+    public FFmpegInputBuilder(FFmpegBuilder parent, String source) {
+        super(parent);
+        device_number = 0;
+        this.input = source;
+    }
+
+    public FFmpegInputBuilder(FFmpegBuilder parent, String source, int device_number) {
+        this(parent, source);
+        this.device_number = device_number;
+    }
+
+    @Override
+    protected FFmpegInputBuilder getThis() {
+        return this;
+    }
+
+    //TO-DO: something here???
+    @Override
+    public EncodingOptions buildOptions() {
+        return null;
+    }
+
+    public FFmpegInputBuilder setThreadQueueSize(int thread_queue_size){
+        this.thread_queue_size = thread_queue_size;
+        this.addExtraArgs("-thread_queue_size", String.valueOf(thread_queue_size));
+        return this;
+    }
+
+    @Override
+    protected List<String> build(FFmpegBuilder parent, int pass) {
+        checkNotNull(parent);
+
+        if (pass > 0) {
+            // TODO Write a test for this:
+            checkArgument(format != null, "Format must be specified when using two-pass");
+        }
+
+        ImmutableList.Builder<String> args = new ImmutableList.Builder<>();
+
+        addGlobalFlags(parent, args);
+
+        if (video_enabled) {
+            addVideoFlags(parent, args);
+        } else {
+            args.add("-vn");
+        }
+
+        if (audio_enabled && pass != 1) {
+            addAudioFlags(args);
+        } else {
+            args.add("-an");
+        }
+
+        if (subtitle_enabled) {
+            if (!Strings.isNullOrEmpty(subtitle_preset)) {
+                args.add("-spre", subtitle_preset);
+            }
+        } else {
+            args.add("-sn");
+        }
+
+        args.addAll(extra_args);
+
+        if (filename != null && uri != null) {
+            throw new IllegalStateException("Only one of filename and uri can be set");
+        }
+
+        // Input
+        if (pass == 1) {
+            args.add(DEVNULL);
+        } else if (input != null) {
+            args.add("-video_device_number", "" + device_number);
+            args.add("-i", input);
+        } else {
+            assert (false);
+        }
+
+        return args.build();
+    }
+}

--- a/src/test/java/net/bramp/ffmpeg/builder/FFmpegBuilderTest.java
+++ b/src/test/java/net/bramp/ffmpeg/builder/FFmpegBuilderTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -431,5 +432,41 @@ public class FFmpegBuilderTest {
         ImmutableList.of(
             "-y", "-v", "error", "-i", "input", "-preset", "a", "-fpre", "b", "-vpre", "c", "-apre",
             "d", "-spre", "e", "output"));
+  }
+
+  @Test
+  public void testFFmpegInputBuilder(){
+    String cmd = "-y -v info -f x11grab -s 1280x720 -r 30/1 -draw_mouse 0 -thread_queue_size 4096 " +
+            "-i :0.0+0,0 -f alsa -thread_queue_size 4096 -i hw:0,1,0 -f flv -acodec aac rtmp://a.rtmp.youtube.com/live2/XXX" ;
+    List<String> args =
+            new FFmpegBuilder()
+            .overrideOutputFiles(true)
+            .setVerbosity(FFmpegBuilder.Verbosity.INFO)
+            .addInputStream(":0.0+0,0")
+              .setFormat("x11grab")
+              .addExtraArgs("-draw_mouse", "0")
+              .setVideoFrameRate(30)
+              .setVideoResolution("1280x720")
+              .setThreadQueueSize(4096)
+              .done()
+            .addInputStream("hw:0,1,0")
+              .setFormat("alsa")
+              .setThreadQueueSize(4096)
+              .done()
+            .addOutput("rtmp://a.rtmp.youtube.com/live2/XXX")
+              .setAudioCodec("aac")
+              .setFormat("flv")
+              .done()
+            .build();
+
+    assertEquals(
+            ImmutableList.copyOf(parseCmd(cmd)),
+            args
+    );
+  }
+
+  //convenience method to parse commands into the immutable list assert form
+  private List<String> parseCmd(String cmd){
+    return Arrays.asList(cmd.split(" "));
   }
 }


### PR DESCRIPTION
I created a subclass called `FFMpegInputBuilder` which extends the `AbstractFFmpegStreamBuilder`. Seeing that the `AbstractFFmpegInputBuilder` was designed for outputs, I re-implemented the filename property and build method to retain all previous functionality.

I also added tests to see that the inputs are built properly, modelled after #156 . I added a convenience method to parse commands separated by spaces for assertion purposes.

From the `FFmpegBuilder`, you simply call `addInputStream(String inputStream)` to build the input.

