### PR TITLE
FEAT Define Appendable to read input and error streams of process

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/FFcommon.java
+++ b/src/main/java/net/bramp/ffmpeg/FFcommon.java
@@ -9,6 +9,7 @@ import net.bramp.ffmpeg.io.ProcessUtils;
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -29,6 +30,12 @@ abstract class FFcommon {
   /** Version string */
   String version = null;
 
+  /** Process input stream */
+  Appendable processInputStream = null;
+
+  /** Process error stream */
+  Appendable processErrorStream = null;
+
   public FFcommon(@Nonnull String path) {
     this(path, new RunProcessFunction());
   }
@@ -39,8 +46,24 @@ abstract class FFcommon {
     this.path = path;
   }
 
+  public void setProcessInputStream(@Nonnull Appendable processInputStream) {
+    this.processInputStream = processInputStream;
+  }
+
+  public void setProcessErrorStream(@Nonnull Appendable processErrorStream) {
+    this.processErrorStream = processErrorStream;
+  }
+
+  private BufferedReader _wrapInReader(final InputStream inputStream) {
+    return new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+  }
+
   protected BufferedReader wrapInReader(Process p) {
-    return new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8));
+    return _wrapInReader(p.getInputStream());
+  }
+
+  protected BufferedReader wrapErrorInReader(Process p) {
+    return _wrapInReader(p.getErrorStream());
   }
 
   protected void throwOnError(Process p) throws IOException {
@@ -108,8 +131,10 @@ abstract class FFcommon {
       // TODO Move the copy onto a thread, so that FFmpegProgressListener can be on this thread.
 
       // Now block reading ffmpeg's stdout. We are effectively throwing away the output.
-      CharStreams.copy(wrapInReader(p), System.out); // TODO Should I be outputting to stdout?
-
+      CharStreams.copy(
+          wrapInReader(p), (processInputStream != null) ? processInputStream : System.out);
+      CharStreams.copy(
+          wrapErrorInReader(p), (processErrorStream != null) ? processErrorStream : System.err);
       throwOnError(p);
 
     } finally {

--- a/src/test/java/net/bramp/ffmpeg/lang/NewProcessAnswer.java
+++ b/src/test/java/net/bramp/ffmpeg/lang/NewProcessAnswer.java
@@ -7,12 +7,21 @@ import org.mockito.stubbing.Answer;
 public class NewProcessAnswer implements Answer<Process> {
   final String resource;
 
+  String errResource = null;
+
   public NewProcessAnswer(String resource) {
     this.resource = resource;
   }
 
+  public NewProcessAnswer(String resource, String errResource) {
+    this.resource = resource;
+    this.errResource = errResource;
+  }
+
   @Override
   public Process answer(InvocationOnMock invocationOnMock) throws Throwable {
-    return new MockProcess(Helper.loadResource(resource));
+    return errResource == null
+        ? new MockProcess(Helper.loadResource(resource))
+        : new MockProcess(null, Helper.loadResource(resource), Helper.loadResource(errResource));
   }
 }

--- a/src/test/resources/net/bramp/ffmpeg/fixtures/ffmpeg-no-such-file
+++ b/src/test/resources/net/bramp/ffmpeg/fixtures/ffmpeg-no-such-file
@@ -1,0 +1,1 @@
+toto.mp4: No such file or directory


### PR DESCRIPTION
Thanks for your amazing library :) I use it into one of my application, and each time FFmpeg process crashes we are not able to get the cause of its interruption. Theses modifications allow defining an Appendable instance to get input and error streams of process.