### PR TITLE
 Update guava to 29.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>20.0</version>
+                <version>29.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
There is a security vulnerability in Google Guava 11.0 through 24.x
before 24.1.1 so we are updating to the latest version.

More details at:
https://ossindex.sonatype.org/vuln/24585a7f-eb6b-4d8d-a2a9-a6f16cc7c1d0