### PR TITLE
Fix the name of the FFMpeg package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ addons:
 
 before_install:
   - ./travis-install-ffmpeg.sh
-  - export FFMPEG=$PWD/ffmpeg-release-64bit-static/ffmpeg
-  - export FFPROBE=$PWD/ffmpeg-release-64bit-static/ffprobe
+  - export FFMPEG=$PWD/ffmpeg-release-amd64-static/ffmpeg
+  - export FFPROBE=$PWD/ffmpeg-release-amd64-static/ffprobe
   - export MAVEN_OPTS="$MAVEN_OPTS -Duser.language=$USER_LANGUAGE -Duser.country=$USER_COUNTRY"
 
 before_script:

--- a/travis-install-ffmpeg.sh
+++ b/travis-install-ffmpeg.sh
@@ -2,7 +2,7 @@
 # Small script to fetch a static ffmpeg
 set -ex
 
-URL=https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
+URL=https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
 FILE=$(basename ${URL})
 DIST=$HOME/.dist
 DISTFILE=${DIST}/${FILE}


### PR DESCRIPTION
The latest release name changed format. It was `64bit` but now it's `amd64`

This should either fix or make progress on the failing build. If the build stops failing, the coveralls report might start working.