### PR TITLE
Propagate FFmpegError through FFmpegException on FFprobe failures

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/FFcommon.java
+++ b/src/main/java/net/bramp/ffmpeg/FFcommon.java
@@ -5,6 +5,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import net.bramp.ffmpeg.io.ProcessUtils;
+import net.bramp.ffmpeg.probe.FFmpegError;
+import net.bramp.ffmpeg.probe.FFmpegProbeResult;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
@@ -49,6 +51,20 @@ abstract class FFcommon {
       if (ProcessUtils.waitForWithTimeout(p, 1, TimeUnit.SECONDS) != 0) {
         // TODO Parse the error
         throw new IOException(path + " returned non-zero exit status. Check stdout.");
+      }
+    } catch (TimeoutException e) {
+      throw new IOException("Timed out waiting for " + path + " to finish.");
+    }
+  }
+
+  protected void throwOnError(Process p, FFmpegProbeResult result) throws IOException {
+    try {
+      // TODO In java 8 use waitFor(long timeout, TimeUnit unit)
+      if (ProcessUtils.waitForWithTimeout(p, 1, TimeUnit.SECONDS) != 0) {
+        // TODO Parse the error
+        final FFmpegError ffmpegError = null == result ? null : result.getError();
+        throw new FFmpegException(
+                path + " returned non-zero exit status. Check stdout.", ffmpegError);
       }
     } catch (TimeoutException e) {
       throw new IOException("Timed out waiting for " + path + " to finish.");

--- a/src/main/java/net/bramp/ffmpeg/FFmpegException.java
+++ b/src/main/java/net/bramp/ffmpeg/FFmpegException.java
@@ -1,0 +1,20 @@
+package net.bramp.ffmpeg;
+
+import net.bramp.ffmpeg.probe.FFmpegError;
+
+import java.io.IOException;
+
+public class FFmpegException extends IOException {
+
+    private static final long serialVersionUID = 3048288225568984942L;
+    private FFmpegError error;
+
+    public FFmpegException(String message, FFmpegError error) {
+        super(message);
+        this.error = error;
+    }
+
+    public FFmpegError getError() {
+        return error;
+    }
+}

--- a/src/main/java/net/bramp/ffmpeg/FFprobe.java
+++ b/src/main/java/net/bramp/ffmpeg/FFprobe.java
@@ -110,7 +110,7 @@ public class FFprobe extends FFcommon {
 
       FFmpegProbeResult result = gson.fromJson(reader, FFmpegProbeResult.class);
 
-      throwOnError(p);
+      throwOnError(p, result);
 
       if (result == null) {
         throw new IllegalStateException("Gson returned null, which shouldn't happen :(");

--- a/src/test/java/net/bramp/ffmpeg/FFprobeTest.java
+++ b/src/test/java/net/bramp/ffmpeg/FFprobeTest.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import net.bramp.ffmpeg.fixtures.Samples;
 import net.bramp.ffmpeg.lang.NewProcessAnswer;
 import net.bramp.ffmpeg.probe.FFmpegChapter;
+import net.bramp.ffmpeg.probe.FFmpegError;
 import net.bramp.ffmpeg.probe.FFmpegProbeResult;
 import net.bramp.ffmpeg.probe.FFmpegStream;
 import org.apache.commons.lang3.math.Fraction;
@@ -11,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
@@ -25,6 +27,7 @@ import static org.mockito.Mockito.*;
 public class FFprobeTest {
 
   @Mock ProcessFunction runFunc;
+  @Mock Process mockProcess;
 
   FFprobe ffprobe;
 
@@ -142,5 +145,18 @@ public class FFprobeTest {
     assertThat(info.getStreams().get(1).codec_time_base, is(Fraction.ZERO));
 
     // System.out.println(FFmpegUtils.getGson().toJson(info));
+  }
+
+  @Test
+  public void shouldThrowOnErrorWithFFmpegProbeResult() throws IOException, InterruptedException {
+    Mockito.when(mockProcess.waitFor()).thenReturn(-1);
+    final FFmpegError error = new FFmpegError();
+    final FFmpegProbeResult result = new FFmpegProbeResult();
+    result.error = error;
+    try {
+      ffprobe.throwOnError(mockProcess, result);
+    } catch (FFmpegException e) {
+      assertEquals(error, e.getError());
+    }
   }
 }


### PR DESCRIPTION
Similar idea to https://github.com/bramp/ffmpeg-cli-wrapper/pull/214 but for ffprobe. Ffprobe actually already deserialises the errors into FFmpegError (Error codes too!) in the FFmpegProbeResult. The result is never returned though as we discard everything and throw IOException.

This change throws FFmpegException which contains the FFmpegError and will allow consumers to easily handle things like 401/404 scenarios on remote files.