### PR TITLE
Added method for using two pass with progress to class FFmpegExecutor

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/FFmpegExecutor.java
+++ b/src/main/java/net/bramp/ffmpeg/FFmpegExecutor.java
@@ -45,4 +45,8 @@ public class FFmpegExecutor {
   public FFmpegJob createTwoPassJob(FFmpegBuilder builder) {
     return new TwoPassFFmpegJob(ffmpeg, builder);
   }
+
+  public FFmpegJob createTwoPassJob(FFmpegBuilder builder, ProgressListener listener) {
+    return new TwoPassFFmpegJob(ffmpeg, builder, listener);
+  }
 }


### PR DESCRIPTION
The class ```TwoPassFFmpegJob``` had a method in it for including a ```ProgressListener```, but ```FFmpegExecutor``` did not have a method that would employ it. I simply added the method to the executor, tested it and it works fine.

I am curious, however ... ```ffmpeg``` has a command-line switch for two pass encoding, but this library seems to accomplish this manually ... why not just use the option that is built into ```ffmpeg```?