### PR TITLE
public the Enum Codec.Type

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/info/Codec.java
+++ b/src/main/java/net/bramp/ffmpeg/info/Codec.java
@@ -13,7 +13,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 @Immutable
 public class Codec {
 
-  enum Type {
+  public enum Type {
     VIDEO,
     AUDIO,
     SUBTITLE

--- a/src/test/java/net/bramp/ffmpeg/info/FFmpegGetInfoTest.java
+++ b/src/test/java/net/bramp/ffmpeg/info/FFmpegGetInfoTest.java
@@ -1,0 +1,42 @@
+package net.bramp.ffmpeg.info;
+
+
+import net.bramp.ffmpeg.FFmpeg;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FFmpegGetInfoTest {
+
+    private List<Codec> videoCodecs = new ArrayList<>();
+    private List<Codec> audioCodecs = new ArrayList<>();
+    private List<Codec> subtitleCodecs = new ArrayList<>();
+
+    @Test
+    public void getFFmpegCodecSupportTest() throws IOException {
+        FFmpeg ffmpeg = new FFmpeg("D:\\Downloads\\ffmpeg\\bin\\ffmpeg.exe");
+        ffmpeg.codecs();
+
+        for (Codec codec : ffmpeg.codecs()) {
+            switch (codec.getType()){
+                case VIDEO:
+                    videoCodecs.add(codec);
+                case AUDIO:
+                    audioCodecs.add(codec);
+                case SUBTITLE:
+                    subtitleCodecs.add(codec);
+
+            }
+        }
+
+        System.out.println("Video codecs: " + Arrays.toString(videoCodecs.toArray()));
+        System.out.println("Audio codecs: " + Arrays.toString(audioCodecs.toArray()));
+        System.out.println("Subtitle codecs: " + Arrays.toString(subtitleCodecs.toArray()));
+    }
+}


### PR DESCRIPTION
When I wanna use the code in `FFmpegGetInfoTest`, but I found that the inner Enum `Codec.Type` is unable to access in the outside. 
 So just simpley public this Enum please~