### PR TITLE
Fix #264: Add additional CodecTypes to FFmpegStream

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/probe/FFmpegStream.java
+++ b/src/main/java/net/bramp/ffmpeg/probe/FFmpegStream.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.math.Fraction;
     justification = "POJO objects where the fields are populated by gson")
 public class FFmpegStream {
 
-  // TODO Add more CodecTypes
   public enum CodecType {
     VIDEO,
     AUDIO,

--- a/src/main/java/net/bramp/ffmpeg/probe/FFmpegStream.java
+++ b/src/main/java/net/bramp/ffmpeg/probe/FFmpegStream.java
@@ -13,6 +13,9 @@ public class FFmpegStream {
   public enum CodecType {
     VIDEO,
     AUDIO,
+    SUBTITLE,
+    DATA,
+    ATTACHMENT
   }
 
   public int index;


### PR DESCRIPTION
I've added the required CodecTypes for `SUBTITLE` and `ATTACHMENT`.
Additionally, I've added the `DATA` CodecType.

@bramp: These are all CodecTypes according to [Documentation](https://ffmpeg.org/ffmpeg.html#toc-Description).
Therefore, I fink we could also remove the corresponding TODO comment.

Fix #264
Fix #259 