### PR TITLE
Fix broken test: Mock runFunc and add assertions to FFmpegGetInfoTest

### DIFF
--- a/src/test/java/net/bramp/ffmpeg/info/FFmpegGetInfoTest.java
+++ b/src/test/java/net/bramp/ffmpeg/info/FFmpegGetInfoTest.java
@@ -2,41 +2,77 @@ package net.bramp.ffmpeg.info;
 
 
 import net.bramp.ffmpeg.FFmpeg;
+import net.bramp.ffmpeg.ProcessFunction;
+import net.bramp.ffmpeg.lang.NewProcessAnswer;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+
+import static net.bramp.ffmpeg.FFmpegTest.argThatHasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FFmpegGetInfoTest {
+  @Mock
+  ProcessFunction runFunc;
 
-    private List<Codec> videoCodecs = new ArrayList<>();
-    private List<Codec> audioCodecs = new ArrayList<>();
-    private List<Codec> subtitleCodecs = new ArrayList<>();
+  @Before
+  public void before() throws IOException {
+    when(runFunc.run(argThatHasItem("-version")))
+        .thenAnswer(new NewProcessAnswer("ffmpeg-version"));
 
-    @Test
-    public void getFFmpegCodecSupportTest() throws IOException {
-        FFmpeg ffmpeg = new FFmpeg("D:\\Downloads\\ffmpeg\\bin\\ffmpeg.exe");
-        ffmpeg.codecs();
+    when(runFunc.run(argThatHasItem("-codecs")))
+        .thenAnswer(new NewProcessAnswer("ffmpeg-codecs"));
+  }
 
-        for (Codec codec : ffmpeg.codecs()) {
-            switch (codec.getType()){
-                case VIDEO:
-                    videoCodecs.add(codec);
-                case AUDIO:
-                    audioCodecs.add(codec);
-                case SUBTITLE:
-                    subtitleCodecs.add(codec);
+  @Test
+  public void getFFmpegCodecSupportTest() throws IOException {
+    List<Codec> videoCodecs = new ArrayList<>();
+    List<Codec> audioCodecs = new ArrayList<>();
+    List<Codec> subtitleCodecs = new ArrayList<>();
+    List<Codec> dataCodecs = new ArrayList<>();
+    List<Codec> otherCodecs = new ArrayList<>();
 
-            }
-        }
+    FFmpeg ffmpeg = new FFmpeg("ffmpeg", runFunc);
+    ffmpeg.codecs();
 
-        System.out.println("Video codecs: " + Arrays.toString(videoCodecs.toArray()));
-        System.out.println("Audio codecs: " + Arrays.toString(audioCodecs.toArray()));
-        System.out.println("Subtitle codecs: " + Arrays.toString(subtitleCodecs.toArray()));
+    for (Codec codec : ffmpeg.codecs()) {
+      switch (codec.getType()) {
+        case VIDEO:
+          videoCodecs.add(codec);
+          break;
+        case AUDIO:
+          audioCodecs.add(codec);
+          break;
+        case SUBTITLE:
+          subtitleCodecs.add(codec);
+          break;
+        case DATA:
+          dataCodecs.add(codec);
+          break;
+        default:
+          otherCodecs.add(codec);
+
+      }
     }
+
+    assertThat(videoCodecs, hasSize(245));
+    assertThat(audioCodecs, hasSize(180));
+    assertThat(subtitleCodecs, hasSize(26));
+    assertThat(dataCodecs, hasSize(8));
+    assertThat(otherCodecs, hasSize(0));
+
+    assertThat(videoCodecs, hasItem(hasProperty("name", equalTo("h264"))));
+    assertThat(audioCodecs, hasItem(hasProperty("name", equalTo("aac"))));
+    assertThat(subtitleCodecs, hasItem(hasProperty("name", equalTo("ssa"))));
+    assertThat(dataCodecs, hasItem(hasProperty("name", equalTo("bin_data"))));
+  }
 }


### PR DESCRIPTION
PR #256 added a static reference that cannot be resolved unless we run on a specific environment.
Additionally, the runFunc has not been mocked, resulting in an actual call to the FFmpeg executable.

I have applied the following modifications:
 - Mock load the regular mocks for `ffmpeg -version` and `ffmpeg -codecs`.
 - Break after each case (the old syntax would otherwise fall through and add to all consecutive lists)
 - Add a dataCodecs list and another codecs list (the second one should always be empty unless FFmpeg adds another CodecType)
 - Add assertions for the size of each collection and assert the existence of at least one element within it