### PR TITLE
fix(ffprobe-number-format-exception): fix gson parse SideData.rotatio…

### DIFF
--- a/src/main/java/net/bramp/ffmpeg/FFmpegUtils.java
+++ b/src/main/java/net/bramp/ffmpeg/FFmpegUtils.java
@@ -13,8 +13,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.bramp.commons.lang3.math.gson.FractionAdapter;
 import net.bramp.ffmpeg.adapter.FFmpegPacketsAndFramesAdapter;
+import net.bramp.ffmpeg.adapter.FFmpegStreamSideDataAdapter;
 import net.bramp.ffmpeg.gson.LowercaseEnumTypeAdapterFactory;
 import net.bramp.ffmpeg.probe.FFmpegFrameOrPacket;
+import net.bramp.ffmpeg.probe.FFmpegStream;
 import org.apache.commons.lang3.math.Fraction;
 
 /** Helper class with commonly used methods */
@@ -130,6 +132,7 @@ public final class FFmpegUtils {
     builder.registerTypeAdapterFactory(new LowercaseEnumTypeAdapterFactory());
     builder.registerTypeAdapter(Fraction.class, new FractionAdapter());
     builder.registerTypeAdapter(FFmpegFrameOrPacket.class, new FFmpegPacketsAndFramesAdapter());
+    builder.registerTypeAdapter(FFmpegStream.SideData.class, new FFmpegStreamSideDataAdapter());
 
     return builder.create();
   }

--- a/src/main/java/net/bramp/ffmpeg/adapter/FFmpegStreamSideDataAdapter.java
+++ b/src/main/java/net/bramp/ffmpeg/adapter/FFmpegStreamSideDataAdapter.java
@@ -1,0 +1,28 @@
+package net.bramp.ffmpeg.adapter;
+
+import com.google.gson.*;
+import net.bramp.ffmpeg.probe.FFmpegStream;
+
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+
+public class FFmpegStreamSideDataAdapter implements JsonDeserializer<FFmpegStream.SideData> {
+    @Override
+    public FFmpegStream.SideData deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+        if (!(jsonElement instanceof JsonObject)) return null;
+        try {
+            Object sideData = Class.forName(FFmpegStream.SideData.class.getName()).newInstance();
+            Field[] fields = Class.forName(FFmpegStream.SideData.class.getName()).getFields();
+            for (Field field: fields) {
+                String fieldName = field.getName();
+                AnnotatedType annotatedType = field.getAnnotatedType();
+                Object deserialize = jsonDeserializationContext.deserialize(((JsonObject) jsonElement).get(fieldName), annotatedType.getType());
+                field.set(sideData, deserialize);
+            }
+            return (FFmpegStream.SideData) sideData;
+        } catch (Exception exception) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/bramp/ffmpeg/adapter/FFmpegStreamSideDataAdapter.java
+++ b/src/main/java/net/bramp/ffmpeg/adapter/FFmpegStreamSideDataAdapter.java
@@ -12,7 +12,7 @@ public class FFmpegStreamSideDataAdapter implements JsonDeserializer<FFmpegStrea
     public FFmpegStream.SideData deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
         if (!(jsonElement instanceof JsonObject)) return null;
         try {
-            Object sideData = Class.forName(FFmpegStream.SideData.class.getName()).newInstance();
+            Object sideData = Class.forName(FFmpegStream.SideData.class.getName()).getConstructor().newInstance();
             Field[] fields = Class.forName(FFmpegStream.SideData.class.getName()).getFields();
             for (Field field: fields) {
                 String fieldName = field.getName();

--- a/src/test/java/net/bramp/ffmpeg/adapter/FFmpegStreamSideDataAdapterTest.java
+++ b/src/test/java/net/bramp/ffmpeg/adapter/FFmpegStreamSideDataAdapterTest.java
@@ -1,0 +1,36 @@
+package net.bramp.ffmpeg.adapter;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.bramp.ffmpeg.probe.FFmpegStream;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FFmpegStreamSideDataAdapterTest {
+    static Gson gson;
+    @BeforeClass
+    public static void setGson() {
+        GsonBuilder builder = new GsonBuilder();
+        builder.registerTypeAdapter(FFmpegStream.SideData.class, new FFmpegStreamSideDataAdapter());
+        gson = builder.create();
+    }
+
+    @Test
+    public void testNumberFormatException() {
+        FFmpegStream.SideData sideData = gson.fromJson("{\"side_data_type\": \"Display Matrix\", \"displaymatrix\": \"\n00000000:            0           0           0\n00000001:            0           0           0\n00000002:            0           0  1073741824\n\", \"rotation\": -9223372036854775808}", FFmpegStream.SideData.class);
+        assertEquals(sideData.side_data_type,  "Display Matrix");
+        assertEquals(sideData.displaymatrix,  "\n00000000:            0           0           0\n00000001:            0           0           0\n00000002:            0           0  1073741824\n");
+        assertEquals(sideData.rotation,  0);
+    }
+
+    @Test
+    public void testNormalVideo() {
+        FFmpegStream.SideData sideData = gson.fromJson("{\"side_data_type\": \"Display Matrix\", \"displaymatrix\": \"\n00000000:            0      -65536           0\n00000001:        65536           0           0\n00000002:            0           0  1073741824\n\", \"rotation\": 90}", FFmpegStream.SideData.class);
+        assertEquals(sideData.side_data_type,  "Display Matrix");
+        assertEquals(sideData.displaymatrix, "\n00000000:            0      -65536           0\n00000001:        65536           0           0\n00000002:            0           0  1073741824\n");
+        assertEquals(sideData.rotation,  90);
+    }
+
+}


### PR DESCRIPTION
#356 

hello，I've solved this issue problem by create an  gson  type adapter which is SideData class。

i write the test for the adapter,  here is the NumberFormatException video


https://github.com/user-attachments/assets/a9a6b0a4-bc54-445b-a1cc-cb9c91c6c27b


actually, the  number "-9223372036854775808"  is -2^63,  and in signed 64bit integer type, which is zero。

